### PR TITLE
Remove componentWillUpdate() from Cell - not actually necessary

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -21,10 +21,6 @@ export class Cell extends React.PureComponent<CellProps> {
     this.drawCellState();
   };
 
-  public componentWillUpdate = () => {
-    this.drawCellState();
-  };
-
   public render() {
     return (
       <canvas


### PR DESCRIPTION
Fixes https://github.com/DylanSp/tic-tac-toe-react/issues/36.

Cell won't draw anything on its canvas on the initial render, but it doesn't need to - on the first render, the game board's empty anyways.